### PR TITLE
Enforce landlord/tenant route separation with role cookie and middlew…

### DIFF
--- a/app/components/auth/RememberMeBootstrap.tsx
+++ b/app/components/auth/RememberMeBootstrap.tsx
@@ -3,10 +3,17 @@
 import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { restoreSessionFromRememberMe } from "@/lib/rememberMe";
+import {
+  getDashboardHomeForRole,
+  getStoredSession,
+  isPathAllowedForRole,
+  resolveNrvRole,
+  syncRoleCookieFromSession,
+} from "@/lib/authSession";
 
 /**
- * On first load, if there is no nrv-user session, try restoring from the
- * httpOnly remember-me cookie. If restored while on sign-in, redirect home.
+ * On first load, sync role cookie from local session (or restore from remember-me).
+ * Redirect away from the wrong role dashboard if needed.
  */
 export function RememberMeBootstrap({ children }: { children: React.ReactNode }) {
   const [ready, setReady] = useState(false);
@@ -18,23 +25,33 @@ export function RememberMeBootstrap({ children }: { children: React.ReactNode })
 
     const run = async () => {
       try {
-        const existing = localStorage.getItem("nrv-user");
-        if (!existing) {
-          const session = await restoreSessionFromRememberMe();
-          if (
-            !cancelled &&
-            session?.accessToken &&
-            (pathname === "/sign-in" || pathname === "/forgot-password")
-          ) {
-            const accountType = String(
-              session.user?.accountType || "",
-            ).toLowerCase();
-            if (accountType === "tenant") {
-              router.replace("/dashboard/tenant");
-            } else {
-              router.replace("/dashboard/landlord");
-            }
-          }
+        let session = getStoredSession();
+        if (!session?.accessToken) {
+          session = await restoreSessionFromRememberMe();
+        } else {
+          syncRoleCookieFromSession(session);
+        }
+
+        if (cancelled || !session?.accessToken) {
+          return;
+        }
+
+        const role = resolveNrvRole(session.user?.accountType);
+        if (!role) {
+          return;
+        }
+
+        const onAuthPage =
+          pathname === "/sign-in" || pathname === "/forgot-password";
+        if (onAuthPage) {
+          router.replace(getDashboardHomeForRole(role));
+          return;
+        }
+
+        const onRoleArea =
+          pathname.startsWith("/dashboard/") || pathname.startsWith("/onboard/");
+        if (onRoleArea && !isPathAllowedForRole(pathname, role)) {
+          window.location.replace(getDashboardHomeForRole(role));
         }
       } finally {
         if (!cancelled) {
@@ -43,7 +60,7 @@ export function RememberMeBootstrap({ children }: { children: React.ReactNode })
       }
     };
 
-    run();
+    void run();
     return () => {
       cancelled = true;
     };

--- a/app/components/guard/LandlordProtectedRoute.tsx
+++ b/app/components/guard/LandlordProtectedRoute.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import { ReactNode, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   clearAuthSession,
   isSessionIdleExpired,
 } from "@/lib/sessionIdle";
 import { restoreSessionFromRememberMe } from "@/lib/rememberMe";
 import {
+  getDashboardHomeForRole,
   getSessionAccountType,
   getStoredSession,
   isAccessTokenExpired,
   isLandlordAccount,
   isTenantAccount,
+  syncRoleCookieFromSession,
 } from "@/lib/authSession";
 
 interface ProtectedRouteProps {
@@ -25,6 +27,7 @@ interface ProtectedRouteProps {
  */
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const router = useRouter();
+  const pathname = usePathname();
   const [allowed, setAllowed] = useState(false);
 
   useEffect(() => {
@@ -36,7 +39,17 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
       if (reason) {
         params.set("reason", reason);
       }
-      router.replace(`/sign-in${params.toString() ? `?${params}` : ""}`);
+      window.location.replace(
+        `/sign-in${params.toString() ? `?${params}` : ""}`,
+      );
+    };
+
+    const sendToRoleHome = (role: "landlord" | "tenant") => {
+      const home = getDashboardHomeForRole(role);
+      if (pathname === home || pathname.startsWith(`${home}/`)) {
+        return;
+      }
+      window.location.replace(home);
     };
 
     const run = async () => {
@@ -65,10 +78,12 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
       }
 
       const accountType = getSessionAccountType(session);
+      syncRoleCookieFromSession(session);
+
       if (isTenantAccount(accountType)) {
         if (!cancelled) {
           setAllowed(false);
-          router.replace("/dashboard/tenant");
+          sendToRoleHome("tenant");
         }
         return;
       }
@@ -92,7 +107,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
     return () => {
       cancelled = true;
     };
-  }, [router]);
+  }, [router, pathname]);
 
   if (!allowed) {
     return (

--- a/app/components/guard/TenantProtectedRoute.tsx
+++ b/app/components/guard/TenantProtectedRoute.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import { ReactNode, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   clearAuthSession,
   isSessionIdleExpired,
 } from "@/lib/sessionIdle";
 import { restoreSessionFromRememberMe } from "@/lib/rememberMe";
 import {
+  getDashboardHomeForRole,
   getSessionAccountType,
   getStoredSession,
   isAccessTokenExpired,
   isLandlordAccount,
   isTenantAccount,
+  syncRoleCookieFromSession,
 } from "@/lib/authSession";
 
 interface ProtectedRouteProps {
@@ -25,6 +27,7 @@ interface ProtectedRouteProps {
  */
 const TenantProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const router = useRouter();
+  const pathname = usePathname();
   const [allowed, setAllowed] = useState(false);
 
   useEffect(() => {
@@ -36,7 +39,17 @@ const TenantProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
       if (reason) {
         params.set("reason", reason);
       }
-      router.replace(`/sign-in${params.toString() ? `?${params}` : ""}`);
+      window.location.replace(
+        `/sign-in${params.toString() ? `?${params}` : ""}`,
+      );
+    };
+
+    const sendToRoleHome = (role: "landlord" | "tenant") => {
+      const home = getDashboardHomeForRole(role);
+      if (pathname === home || pathname.startsWith(`${home}/`)) {
+        return;
+      }
+      window.location.replace(home);
     };
 
     const run = async () => {
@@ -65,10 +78,12 @@ const TenantProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
       }
 
       const accountType = getSessionAccountType(session);
+      syncRoleCookieFromSession(session);
+
       if (isLandlordAccount(accountType)) {
         if (!cancelled) {
           setAllowed(false);
-          router.replace("/dashboard/landlord");
+          sendToRoleHome("landlord");
         }
         return;
       }
@@ -92,7 +107,7 @@ const TenantProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
     return () => {
       cancelled = true;
     };
-  }, [router]);
+  }, [router, pathname]);
 
   if (!allowed) {
     return (

--- a/app/components/screens/sign-in/hooks/useAuthRedirect.ts
+++ b/app/components/screens/sign-in/hooks/useAuthRedirect.ts
@@ -2,6 +2,13 @@ import { useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { UserData } from "../types";
 import { ROUTES } from "../constants";
+import {
+  isLandlordAccount,
+  isPathAllowedForRole,
+  isTenantAccount,
+  setRoleCookie,
+  type NrvRole,
+} from "@/lib/authSession";
 
 export const useAuthRedirect = () => {
   const router = useRouter();
@@ -10,6 +17,16 @@ export const useAuthRedirect = () => {
   const redirectUser = useCallback((userData: UserData) => {
     const userAccountType = String(userData?.user?.accountType || "").toLowerCase();
     const userStatus = String(userData?.user?.status || "");
+
+    const role: NrvRole | null = isTenantAccount(userAccountType)
+      ? "tenant"
+      : isLandlordAccount(userAccountType)
+        ? "landlord"
+        : null;
+
+    if (role) {
+      setRoleCookie(role);
+    }
 
     const redirectFromQuery =
       searchParams.get("redirect") || searchParams.get("returnUrl");
@@ -48,8 +65,8 @@ export const useAuthRedirect = () => {
         return;
       }
 
-      // Other deep links (best-effort).
-      if (safeRedirect) {
+      // Deep links only when they match this account's role area.
+      if (safeRedirect && role && isPathAllowedForRole(safeRedirect, role)) {
         router.push(safeRedirect);
         return;
       }

--- a/lib/authSession.ts
+++ b/lib/authSession.ts
@@ -2,6 +2,8 @@
  * Client-side session helpers for dashboard route guards.
  */
 
+export const NRV_ROLE_COOKIE = "nrv_role";
+
 export type NrvSessionUser = {
   _id?: string;
   id?: string;
@@ -14,6 +16,8 @@ export type NrvSession = {
   accessToken?: string;
   user?: NrvSessionUser;
 };
+
+export type NrvRole = "landlord" | "tenant";
 
 export const getStoredSession = (): NrvSession | null => {
   if (typeof window === "undefined") {
@@ -73,3 +77,72 @@ export const isTenantAccount = (accountType?: string | null): boolean =>
   String(accountType || "")
     .trim()
     .toLowerCase() === "tenant";
+
+export const resolveNrvRole = (
+  accountType?: string | null,
+): NrvRole | null => {
+  if (isTenantAccount(accountType)) {
+    return "tenant";
+  }
+  if (isLandlordAccount(accountType)) {
+    return "landlord";
+  }
+  return null;
+};
+
+const getCookieMaxAgeSeconds = (): number => 60 * 60 * 24 * 30;
+
+/** Readable role cookie for Next middleware (not httpOnly). */
+export const setRoleCookie = (accountType?: string | null): void => {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const role = resolveNrvRole(accountType);
+  if (!role) {
+    clearRoleCookie();
+    return;
+  }
+  const secure =
+    typeof window !== "undefined" && window.location.protocol === "https:"
+      ? "; Secure"
+      : "";
+  document.cookie = `${NRV_ROLE_COOKIE}=${role}; Path=/; Max-Age=${getCookieMaxAgeSeconds()}; SameSite=Lax${secure}`;
+};
+
+export const clearRoleCookie = (): void => {
+  if (typeof document === "undefined") {
+    return;
+  }
+  document.cookie = `${NRV_ROLE_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`;
+};
+
+export const syncRoleCookieFromSession = (
+  session?: NrvSession | null,
+): NrvRole | null => {
+  const role = resolveNrvRole(getSessionAccountType(session));
+  if (!role) {
+    clearRoleCookie();
+    return null;
+  }
+  setRoleCookie(role);
+  return role;
+};
+
+export const getDashboardHomeForRole = (role: NrvRole): string =>
+  role === "tenant" ? "/dashboard/tenant" : "/dashboard/landlord";
+
+export const isPathAllowedForRole = (
+  pathname: string,
+  role: NrvRole,
+): boolean => {
+  if (role === "tenant") {
+    return (
+      pathname.startsWith("/dashboard/tenant") ||
+      pathname.startsWith("/onboard/tenant")
+    );
+  }
+  return (
+    pathname.startsWith("/dashboard/landlord") ||
+    pathname.startsWith("/onboard/landlord")
+  );
+};

--- a/lib/rememberMe.ts
+++ b/lib/rememberMe.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { API_URL } from "@/config/constant";
 import { touchSessionActivity } from "@/lib/sessionIdle";
+import { syncRoleCookieFromSession } from "@/lib/authSession";
 
 export type RestoredSession = {
   user: any;
@@ -12,6 +13,7 @@ const persistSession = (userData: RestoredSession) => {
   localStorage.setItem("nrv-user", JSON.stringify(userData));
   localStorage.setItem("rememberMe", "true");
   touchSessionActivity();
+  syncRoleCookieFromSession(userData);
 };
 
 /**

--- a/lib/sessionIdle.ts
+++ b/lib/sessionIdle.ts
@@ -1,3 +1,5 @@
+import { clearRoleCookie } from "@/lib/authSession";
+
 export const SESSION_IDLE_MS = 30 * 60 * 1000;
 export const SESSION_LAST_ACTIVE_KEY = "nrv-last-active";
 export const REMEMBER_ME_FLAG_KEY = "rememberMe";
@@ -48,6 +50,7 @@ export const clearAuthSession = () => {
   localStorage.removeItem(SESSION_LAST_ACTIVE_KEY);
   localStorage.removeItem(REMEMBER_ME_FLAG_KEY);
   localStorage.removeItem("rememberedEmail");
+  clearRoleCookie();
 };
 
 export const expireIdleSession = (message?: string) => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,21 +1,47 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const ROLE_COOKIE = "nrv_role";
 
 export function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
   // Chrome DevTools – return empty JSON so the request doesn't 404
-  if (pathname === '/.well-known/appspecific/com.chrome.devtools.json') {
+  if (pathname === "/.well-known/appspecific/com.chrome.devtools.json") {
     return NextResponse.json({});
   }
 
   // react-toastify source maps – return 204 so the request doesn't 404
   if (
-    pathname.endsWith('.map') &&
-    (pathname.includes('react-toastify') || pathname.includes('ReactToastify'))
+    pathname.endsWith(".map") &&
+    (pathname.includes("react-toastify") || pathname.includes("ReactToastify"))
   ) {
     return new NextResponse(null, { status: 204 });
   }
 
+  const role = request.cookies.get(ROLE_COOKIE)?.value;
+  const isLandlordPath =
+    pathname.startsWith("/dashboard/landlord") ||
+    pathname.startsWith("/onboard/landlord");
+  const isTenantPath =
+    pathname.startsWith("/dashboard/tenant") ||
+    pathname.startsWith("/onboard/tenant");
+
+  // Enforce role cookie when present (set on login / session restore).
+  if (role === "tenant" && isLandlordPath) {
+    return NextResponse.redirect(new URL("/dashboard/tenant", request.url));
+  }
+  if (role === "landlord" && isTenantPath) {
+    return NextResponse.redirect(new URL("/dashboard/landlord", request.url));
+  }
+
   return NextResponse.next();
 }
+
+export const config = {
+  matcher: [
+    "/dashboard/:path*",
+    "/onboard/:path*",
+    "/.well-known/appspecific/com.chrome.devtools.json",
+  ],
+};

--- a/redux/slices/userSlice.ts
+++ b/redux/slices/userSlice.ts
@@ -289,6 +289,8 @@ export const loginUser = createAsyncThunk<UserToken, LoginFormData>(
       // For inactive users, store the email so they can verify, but don't create a session token.
       if (userData?.user?.status === "inactive") {
         localStorage.removeItem("nrv-user");
+        const { clearRoleCookie } = await import("@/lib/authSession");
+        clearRoleCookie();
         if (userData?.user?.email) {
           localStorage.setItem("emailToVerify", JSON.stringify({ data: { email: userData.user.email } }));
         }
@@ -301,7 +303,9 @@ export const loginUser = createAsyncThunk<UserToken, LoginFormData>(
           localStorage.removeItem("rememberMe");
         }
         const { touchSessionActivity } = await import("@/lib/sessionIdle");
+        const { syncRoleCookieFromSession } = await import("@/lib/authSession");
         touchSessionActivity();
+        syncRoleCookieFromSession(userData);
       }
       return userData;
     } catch (error: any) {


### PR DESCRIPTION
…are.

Block cross-role dashboard access at the edge and hard-redirect client guards so tenants and landlords cannot open each other's areas.